### PR TITLE
use generic xarray without specifying version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ REQUIRED = [
     'torch',
     "model-tools @ git+https://github.com/brain-score/model-tools",
     "numpy",
-    'xarray==0.16.1',
+    'xarray',
     "result_caching @ git+https://github.com/mschrimpf/result_caching"
 ]
 


### PR DESCRIPTION
otherwise this will lead to dependency issues in the future when brain-score uses a newer version